### PR TITLE
Fixes #5 - Fix for file not written on Linux

### DIFF
--- a/qml/qml_qt5/CuraHtmlDoc.qml
+++ b/qml/qml_qt5/CuraHtmlDoc.qml
@@ -37,7 +37,7 @@ Item
 
 		// On Linux, a forward slash needs to be prepended to the resulting path
 		// I'm guessing this is needed on Mac OS, as well, but can't test it
-		if (Cura.os == "linux" || Cura.os == "darwin") path = "/" + path
+		if (Qt.platform.os === "linux" || Qt.platform.os === "osx" || Qt.platform.os === "unix") path = "/" + path
 		
 		// Return the resulting path
 		return path

--- a/qml/qml_qt6/CuraHtmlDoc.qml
+++ b/qml/qml_qt6/CuraHtmlDoc.qml
@@ -38,7 +38,7 @@ Item
 
 		// On Linux, a forward slash needs to be prepended to the resulting path
 		// I'm guessing this is needed on Mac OS, as well, but can't test it
-		if (Cura.os == "linux" || Cura.os == "darwin") path = "/" + path
+		if (Qt.platform.os === "linux" || Qt.platform.os === "osx" || Qt.platform.os === "unix") path = "/" + path
 		
 		// Return the resulting path
 		return path


### PR DESCRIPTION
This PR provides a tested fix for the file not being created on Linux. `Cura.os` no longer works, which was causing the leading `/` to not be prepended to the path. The fix I've used was referenced in a number of places online, and should work on any POSIX-compatible OS (Linux/Mac/Unix) that uses file paths starting with `/`.

Note that after this fix, the first time you try to use "Save As" from the plugin, there will be an error message about a `smb://` path not being able to be opened. However the file selection dialog will open properly and allow you to save the HTML.